### PR TITLE
RFC: Add new wait methods for async handling

### DIFF
--- a/packages/rut/tests/Result.test.tsx
+++ b/packages/rut/tests/Result.test.tsx
@@ -656,7 +656,7 @@ describe('Result', () => {
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
-      it('supports async `useEffect`', async () => {
+      it.only('supports async `useEffect`', async () => {
         const spy = jest.fn();
 
         const result = render<AsyncProps>(<AsyncHookComp id="first" onLoad={spy} />);
@@ -664,7 +664,9 @@ describe('Result', () => {
         expect(spy).toHaveBeenCalledTimes(0);
         expect(result.root).toContainNode('Loading...');
 
-        await result.updateAndWait({ id: 'second' });
+        result.update({ id: 'second' });
+
+        await result.waitForNode('Loaded');
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(result.root).toContainNode('Loaded');


### PR DESCRIPTION
Testing async is easy but testing async React is very hard, as React is async by design and its async implementation is abstracted away. For example, state changes are batched and scheduled using their own `scheduler` API (which has a custom timer implementation, not `setTimeout`), which provides no means of hooking into. When you render a component, the initial result you expect against may change in the future, unbeknownst to you, unless you explicitly wait for the changes to happen. Otherwise, those changes are pretty much discarded and happen in the background (and may also cause Jest async/timeout issues).

These async issues will be further exacerbated by `ConcurrentMode`.

### Current approaches

In Rut, I try to abstract async handling away from the consumer, as it's very hard to do correctly, and should just "work". At the moment Rut provides 2 approaches, both not currently viable in the long run.

- Wraps `Promise`, `setTimeout`, and `setInterval` to capture all async calls and resolve the rendered result when they complete. This works for small test cases, but once the React tree grows very large, the amount of async calls/ticks grows unwieldy, resulting in promises never resolving (and crashing tests). This also has the negative effect of modifying globals.

- Uses Node's [async_hooks](https://nodejs.org/api/async_hooks.html) to capture all `Promise`, `setTimeout`, and `setInterval` calls using an execution context, and resolve the rendered result when they complete. This is much more accurate than the previous approach, but has the downside of capturing async calls from Jest or Node itself. It's currently problematic as sync renders that have async calls are not properly captured, and leak between renders. The performance on large trees is also very poor.

### Suggested approaches

Since the previous approaches are not 100% viable at this point in time, I've been trying to brainstorm new async handling APIs that do not involve wrapping or mutating the Node process. The new API is the following 3 methods:

- `Result#waitForNodeMount(node)` - Runs on an interval and resolves once a specific node is found within the React tree (for example, when a loading state finishes).
- `Result#waitForNodeUnmount(node)` - Opposite of the previous method. Waits until a node is removed from the React tree.
- `Result#waitForPropChange(prop, value?)` - Runs on an interval and resolves once the element's prop has changed from it's initial render.

The first 2 methods are far more accurate, but since they traverse the tree every X milliseconds, it's unknown what performance loss/cost these will take. Usually, since promises happen within next tick, this only ever loops once. The outlier to this is when waiting for `setTimeout` calls.

> These new APIs are similar to `react-testing-library`s `waitForElement` queries.

### Alternatives

One long-shot alternative is updating `react-test-renderer` upstream to provide better support in this area. This is currently an unknown on feasibility.